### PR TITLE
Implement feedback Frodrigo

### DIFF
--- a/plugins/Highway_Parking_Lane.py
+++ b/plugins/Highway_Parking_Lane.py
@@ -78,8 +78,8 @@ be tagged on that object instead.'''))
         if len(sides) > 0:
             err.append({"class": 31611})
 
-        if "parking:lane:both" in tags and (("parking:lane:right" in tags and tags["parking:lane:right"] == tags["parking:lane:both"]) or 
-                                            ("parking:lane:left" in tags and tags["parking:lane:left"] == tags["parking:lane:both"]):
+        if "parking:lane:both" in tags and (("parking:lane:right" in tags and tags["parking:lane:right"] == tags["parking:lane:both"]) or
+                                            ("parking:lane:left" in tags and tags["parking:lane:left"] == tags["parking:lane:both"])):
             # Conflicting values are dealt with in Highway_Sides
             err.append({"class": 31614})
 

--- a/plugins/Highway_Parking_Lane.py
+++ b/plugins/Highway_Parking_Lane.py
@@ -78,7 +78,9 @@ be tagged on that object instead.'''))
         if len(sides) > 0:
             err.append({"class": 31611})
 
-        if ("parking:lane:right" in tags or "parking:lane:left" in tags) and "parking:lane:both" in tags:
+        if "parking:lane:both" in tags and (("parking:lane:right" in tags and tags["parking:lane:right"] == tags["parking:lane:both"]) or 
+                                            ("parking:lane:left" in tags and tags["parking:lane:left"] == tags["parking:lane:both"]):
+            # Conflicting values are dealt with in Highway_Sides
             err.append({"class": 31614})
 
         for side in ("parking:lane:right", "parking:lane:left", "parking:lane:both"):
@@ -120,6 +122,7 @@ class Test(TestPluginCommon):
 
         for t in [{"highway": "r", "parking:lane:both:parallel": "t"},
                   {"highway": "r", "parking:condition:both": "private", "parking:lane:both": "perpendicular"},
+                  {"highway": "r", "parking:lane:right": "parallel", "parking:lane:both": "no"}, # Checked by Highway_Sides plugin
                   {"highway": "r", "parking:condition:right": "private", "parking:condition:left": "private", "parking:lane:both": "perpendicular"},
                   {"highway": "r", "parking:lane:right": "perpendicular", "parking:condition:right": "customers", "parking:condition:right:capacity": "19"},
                   {"highway": "r", "parking:lane:left": "separate", "parking:lane:right": "parallel"},

--- a/plugins/Highway_Sides.py
+++ b/plugins/Highway_Sides.py
@@ -28,7 +28,7 @@ class Highway_Sides(Plugin):
         Plugin.init(self, logger)
 
         self.errors[33601] = self.def_class(item = 3360, level = 2, tags = ['highway', 'fix:chair'],
-            title = T_('Conflicting tag values'),
+            title = T_('Conflicting tags for sides of the way'),
             detail = T_(
 '''A tag with `:right`, `:left` or `:both` conflicts with the same tag without side specification, or a tag with `:right` or `:left` conflicts with the tag with `:both`.'''))
 


### PR DESCRIPTION
- Make title more specific
- Prevent simultaneous warnings about conflicts (i.e. values `no` and `parallel`) and co-existing `parking:lane:[side]` keys:
If the values conflict, `Highway_Sides` will raise a level 2 warning
If the values do not conflict, `Highway_Parking_Lane` still raises the same level 3 warning