### PR TITLE
Implement condition check for date/time and property comparison

### DIFF
--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -41,6 +41,7 @@ class ConditionalRestrictions(Plugin):
     self.ReSimpleCondition = re.compile(r'^\w+$', re.ASCII)
     self.ReAND = re.compile(r'\band\b', re.IGNORECASE)
     self.currentYear = date.today().year
+    self.comparisonOperatorChars = ["<", "=", ">"]
     # Following regex are to detect likely (possibly misspelled) opening_hours syntaxes
     self.ReWeekdayMonthOpeningH = re.compile(r'\b[A-Z][a-z]') # i.e. Mar or Mo
     self.ReMonthDayOpeningH = re.compile(r'\w\w\w[\s-]\d') # i.e. sep 1
@@ -173,7 +174,7 @@ For example, use `no @ (weight > 5 AND wet)` rather than `no@weight>5 and wet`.'
                 break
             else:
               # Validate vehicle property comparisons
-              if c[0] in [">", "<", "="] or c[-1] in [">", "<", "="]:
+              if c[0] in self.comparisonOperatorChars or c[-1] in self.comparisonOperatorChars:
                 err.append({"class": 33501, "subclass": 5 + stablehash64(tag + '|' + tag_value + '|' + c), "text": T_("Unexpected <, = or > in \"{0}\"", tag)})
                 bad_tag = True
                 break
@@ -210,7 +211,7 @@ For example, use `no @ (weight > 5 AND wet)` rather than `no@weight>5 and wet`.'
     for s in [",", "[", "-", "+", "/"]:
       if s in condition:
         score += 1 # characters not found in many other types of conditionals
-    for s in ["=", "<", ">"]:
+    for s in self.comparisonOperatorChars:
       if s in condition:
         score -= 1 # weight < 25 or so, no meaning in date/time-based conditionals
     if score >= treshold:

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -268,13 +268,14 @@ class Test(TestPluginCommon):
 
         # Invalid or suboptimal conditions in conditionals
         for t in [{"highway": "residential", "access:conditional": "no @ (weight >)"},
-                  {"highway": "residential", "access:conditional": "no @ (weight <= AND wet); destination @ snow"},
+                  {"highway": "residential", "access:conditional": "no @ (foggy AND weight <= AND wet); destination @ snow"},
                   {"highway": "residential", "access:conditional": "no @ (2098-05-22 - 2099-10-7)"},
                   {"highway": "residential", "access:conditional": "no @ (22 mei 2099 - 07 okt 2099)"},
                   {"highway": "residential", "access:conditional": "no @ (JUL 01-JAN 31)"},
                   {"highway": "residential", "access:conditional": "no @ (6h00-19h00)"},
                   {"highway": "residential", "access:conditional": "no @ (Ma-Vr 18:00-20:00); destination @ (length < 4)"},
                   {"highway": "residential", "access:conditional": "no @ (Mei 22 - Okt 7 AND weight > 5)"},
+                  {"highway": "residential", "access:conditional": "no @ (weight > 5 AND mei 22 - okt 7)"},
                  ]:
           assert a.way(None, t, None), a.way(None, t, None)
 

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -257,7 +257,16 @@ class Test(TestPluginCommon):
                  ]:
           assert not a.way(None, t, None), a.way(None, t, None)
 
-        # Invalid or suboptimal conditions
+        # Expired conditionals
+        for t in [{"highway": "residential", "access:forward:conditional": "no @ 2020"},
+                  {"highway": "residential", "access:conditional": "no @ (2018 May 22-2020 Oct 7)"},
+                  {"highway": "residential", "access:conditional": "no @ (2018 May 22-2020 Oct 7); delivery @ 2099"},
+                  {"highway": "residential", "access:conditional": "no @ (2018 May 22-2020 Oct 7); destination @ (length < 4)"},
+                  {"highway": "residential", "access:conditional": "no @ (2018 May 22-2020 Oct 7 AND weight > 5)"},
+                 ]:
+          assert a.way(None, t, None), a.way(None, t, None)
+
+        # Invalid or suboptimal conditions in conditionals
         for t in [{"highway": "residential", "access:conditional": "no @ (weight >)"},
                   {"highway": "residential", "access:conditional": "no @ (weight <= AND wet); destination @ snow"},
                   {"highway": "residential", "access:conditional": "no @ (2098-05-22 - 2099-10-7)"},
@@ -266,15 +275,6 @@ class Test(TestPluginCommon):
                   {"highway": "residential", "access:conditional": "no @ (6h00-19h00)"},
                   {"highway": "residential", "access:conditional": "no @ (Ma-Vr 18:00-20:00); destination @ (length < 4)"},
                   {"highway": "residential", "access:conditional": "no @ (Mei 22 - Okt 7 AND weight > 5)"},
-                 ]:
-          assert a.way(None, t, None), a.way(None, t, None)
-
-        # Expired conditionals
-        for t in [{"highway": "residential", "access:forward:conditional": "no @ 2020"},
-                  {"highway": "residential", "access:conditional": "no @ (2018 May 22-2020 Oct 7)"},
-                  {"highway": "residential", "access:conditional": "no @ (2018 May 22-2020 Oct 7); delivery @ 2099"},
-                  {"highway": "residential", "access:conditional": "no @ (2018 May 22-2020 Oct 7); destination @ (length < 4)"},
-                  {"highway": "residential", "access:conditional": "no @ (2018 May 22-2020 Oct 7 AND weight > 5)"},
                  ]:
           assert a.way(None, t, None), a.way(None, t, None)
 


### PR DESCRIPTION
- Make `AND`-check easier to read
- Test for bad date/time based conditions (such as `2022-03-25`, while the syntax says it should be `2022 May 25`), reusing the code from the `opening_hours` check. Determining whether it's a date/time is based on a scoring system: as we intent to discover bad date/timespans, we cannot check for valid spans only.
- Basic testing for bad usage of `<`, `>` or `=` 
- No longer triggering "expired" warning for i.e. `length > 120200 mm` (i.e. a bigger number containing 2020)