### PR TITLE
Record proper selector indices

### DIFF
--- a/mapcss/MapCSSListenerL.py
+++ b/mapcss/MapCSSListenerL.py
@@ -62,6 +62,7 @@ class MapCSSListenerL(MapCSSListener):
         self.predicates: List[Dict] = []
         self.predicates_function_base: Optional[List[Dict]] = None
         self.pseudo_class = [] # : List[Dict]
+        self.selector_index = 0
 
     # Exit a parse tree produced by MapCSSParser#simple_selector.
     def exitSimple_selector(self, ctx:MapCSSParser.Simple_selectorContext):
@@ -101,7 +102,9 @@ class MapCSSListenerL(MapCSSListener):
             'predicate': v['osmtag'] or v['quoted'] or v['regexExpression'][0],
             'not': not (not (ctx.OP_NOT())),
             'question_mark': not (not (ctx.QUESTION_MARK())),
-            'question_mark_negated': not (not (ctx.QUESTION_MARK_NEGATED()))}
+            'question_mark_negated': not (not (ctx.QUESTION_MARK_NEGATED())),
+            'selector_index': self.selector_index}
+        self.selector_index += 1
 
 
 #    # Enter a parse tree produced by MapCSSParser#class_selector.
@@ -110,7 +113,11 @@ class MapCSSListenerL(MapCSSListener):
 
     # Exit a parse tree produced by MapCSSParser#class_selector.
     def exitClass_selector(self, ctx:MapCSSParser.Class_selectorContext):
-        self.class_selectors.append({'type': 'class_selector', 'not': not (not (ctx.OP_NOT())), 'class': ctx.cssident().getText()})
+        self.class_selectors.append({'type': 'class_selector',
+            'not': not (not (ctx.OP_NOT())),
+            'class': ctx.cssident().getText(),
+            'selector_index': self.selector_index})
+        self.selector_index += 1
 
 
 #    # Enter a parse tree produced by MapCSSParser#pseudo_class_selector.
@@ -119,7 +126,11 @@ class MapCSSListenerL(MapCSSListener):
 
     # Exit a parse tree produced by MapCSSParser#pseudo_class_selector.
     def exitPseudo_class_selector(self, ctx:MapCSSParser.Pseudo_class_selectorContext):
-        self.pseudo_class.append({'type': 'pseudo_class', 'not_class': not (not (ctx.OP_NOT())), 'pseudo_class': ctx.cssident().getText()})
+        self.pseudo_class.append({'type': 'pseudo_class',
+            'not_class': not (not (ctx.OP_NOT())),
+            'pseudo_class': ctx.cssident().getText(),
+            'selector_index': self.selector_index})
+        self.selector_index += 1
 
 
     # Enter a parse tree produced by MapCSSParser#declaration.
@@ -181,8 +192,10 @@ class MapCSSListenerL(MapCSSListener):
             'operands':
                 v['booleanExpressions'] or # Juste get operands array
                 (v['functionExpression'] and [v['functionExpression']]) or
-                []
+                [],
+            'selector_index': self.selector_index
         })
+        self.selector_index += 1
 
 
     # Enter a parse tree produced by MapCSSParser#valueExpression.

--- a/plugins/Josm_combinations.py
+++ b/plugins/Josm_combinations.py
@@ -1286,7 +1286,7 @@ class Josm_combinations(PluginMapCSS):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway') == mapcss._value_capture(capture_tags, 0, 'mini_roundabout')) and (mapcss._tag_capture(capture_tags, 1, tags, 'direction') == mapcss._value_capture(capture_tags, 1, 'clockwise')) and (mapcss.setting(self.father.config.options, 'driving_side') != 'left'))
+                try: match = ((mapcss._tag_capture(capture_tags, 1, tags, 'highway') == mapcss._value_capture(capture_tags, 1, 'mini_roundabout')) and (mapcss._tag_capture(capture_tags, 2, tags, 'direction') == mapcss._value_capture(capture_tags, 2, 'clockwise')) and (mapcss.setting(self.father.config.options, 'driving_side') != 'left'))
                 except mapcss.RuleAbort: pass
             if match:
                 # group:tr("suspicious tag combination")
@@ -1298,7 +1298,7 @@ class Josm_combinations(PluginMapCSS):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway') == mapcss._value_capture(capture_tags, 0, 'mini_roundabout')) and (mapcss._tag_capture(capture_tags, 1, tags, 'direction') == mapcss._value_capture(capture_tags, 1, 'anticlockwise')) and (mapcss.setting(self.father.config.options, 'driving_side') == 'left'))
+                try: match = ((mapcss._tag_capture(capture_tags, 1, tags, 'highway') == mapcss._value_capture(capture_tags, 1, 'mini_roundabout')) and (mapcss._tag_capture(capture_tags, 2, tags, 'direction') == mapcss._value_capture(capture_tags, 2, 'anticlockwise')) and (mapcss.setting(self.father.config.options, 'driving_side') == 'left'))
                 except mapcss.RuleAbort: pass
             if match:
                 # group:tr("suspicious tag combination")
@@ -2863,31 +2863,31 @@ class Josm_combinations(PluginMapCSS):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 0, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 1, tags, 'turn:lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'lanes') != mapcss._value_capture(capture_tags, 2, mapcss.count(mapcss.split('|', mapcss.tag(tags, 'turn:lanes'))))))
+                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 1, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'turn:lanes')) and (mapcss._tag_capture(capture_tags, 3, tags, 'lanes') != mapcss._value_capture(capture_tags, 3, mapcss.count(mapcss.split('|', mapcss.tag(tags, 'turn:lanes'))))))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 0, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 1, tags, 'change:lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'lanes') != mapcss._value_capture(capture_tags, 2, mapcss.count(mapcss.split('|', mapcss.tag(tags, 'change:lanes'))))))
+                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 1, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'change:lanes')) and (mapcss._tag_capture(capture_tags, 3, tags, 'lanes') != mapcss._value_capture(capture_tags, 3, mapcss.count(mapcss.split('|', mapcss.tag(tags, 'change:lanes'))))))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 0, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 1, tags, 'maxspeed:lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'lanes') != mapcss._value_capture(capture_tags, 2, mapcss.count(mapcss.split('|', mapcss.tag(tags, 'maxspeed:lanes'))))))
+                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 1, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'maxspeed:lanes')) and (mapcss._tag_capture(capture_tags, 3, tags, 'lanes') != mapcss._value_capture(capture_tags, 3, mapcss.count(mapcss.split('|', mapcss.tag(tags, 'maxspeed:lanes'))))))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 0, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 1, tags, 'minspeed:lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'lanes') != mapcss._value_capture(capture_tags, 2, mapcss.count(mapcss.split('|', mapcss.tag(tags, 'minspeed:lanes'))))))
+                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 1, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'minspeed:lanes')) and (mapcss._tag_capture(capture_tags, 3, tags, 'lanes') != mapcss._value_capture(capture_tags, 3, mapcss.count(mapcss.split('|', mapcss.tag(tags, 'minspeed:lanes'))))))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 0, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 1, tags, 'destination:lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'lanes') != mapcss._value_capture(capture_tags, 2, mapcss.count(mapcss.split('|', mapcss.tag(tags, 'destination:lanes'))))))
+                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 1, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'destination:lanes')) and (mapcss._tag_capture(capture_tags, 3, tags, 'lanes') != mapcss._value_capture(capture_tags, 3, mapcss.count(mapcss.split('|', mapcss.tag(tags, 'destination:lanes'))))))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 0, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 1, tags, 'destination:ref:lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'lanes') != mapcss._value_capture(capture_tags, 2, mapcss.count(mapcss.split('|', mapcss.tag(tags, 'destination:ref:lanes'))))))
+                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 1, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'destination:ref:lanes')) and (mapcss._tag_capture(capture_tags, 3, tags, 'lanes') != mapcss._value_capture(capture_tags, 3, mapcss.count(mapcss.split('|', mapcss.tag(tags, 'destination:ref:lanes'))))))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 0, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 1, tags, 'destination:symbol:lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'lanes') != mapcss._value_capture(capture_tags, 2, mapcss.count(mapcss.split('|', mapcss.tag(tags, 'destination:symbol:lanes'))))))
+                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 1, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'destination:symbol:lanes')) and (mapcss._tag_capture(capture_tags, 3, tags, 'lanes') != mapcss._value_capture(capture_tags, 3, mapcss.count(mapcss.split('|', mapcss.tag(tags, 'destination:symbol:lanes'))))))
                 except mapcss.RuleAbort: pass
             if match:
                 # group:tr("suspicious tag combination")

--- a/plugins/Josm_geometry.py
+++ b/plugins/Josm_geometry.py
@@ -681,7 +681,7 @@ class Josm_geometry(PluginMapCSS):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'power') == mapcss._value_capture(capture_tags, 0, 'line')) and (nds[0] == nds[-1]))
+                try: match = ((mapcss._tag_capture(capture_tags, 1, tags, 'power') == mapcss._value_capture(capture_tags, 1, 'line')) and (nds[0] == nds[-1]))
                 except mapcss.RuleAbort: pass
             if match:
                 # throwWarning:tr("{0} on a closed way. Should be used on an unclosed way.","{1.tag}")

--- a/plugins/Josm_numeric.py
+++ b/plugins/Josm_numeric.py
@@ -1846,7 +1846,7 @@ class Josm_numeric(PluginMapCSS):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((not set_imprecise_gauge) and (not set_unusual_gauge) and (mapcss.regexp_test(self.re_70dc3282, mapcss._match_regex(tags, self.re_7e626945))) and (mapcss._tag_capture(capture_tags, 0, tags, 'gauge')) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 1, self.re_33ecb9da, '^((14(?:3[0-4]|[4-9])|(?:14[0-2]|(?:1[0-3]|9)[0-9])[0-9]?|143|(?:[2-7][0-9]|1[5-9])[0-9]|8(?:[0-8][0-9]|9[0-9]?));?)+$'), mapcss._tag_capture(capture_tags, 1, tags, 'gauge'))))
+                try: match = ((not set_imprecise_gauge) and (not set_unusual_gauge) and (mapcss.regexp_test(self.re_70dc3282, mapcss._match_regex(tags, self.re_7e626945))) and (mapcss._tag_capture(capture_tags, 1, tags, 'gauge')) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 2, self.re_33ecb9da, '^((14(?:3[0-4]|[4-9])|(?:14[0-2]|(?:1[0-3]|9)[0-9])[0-9]?|143|(?:[2-7][0-9]|1[5-9])[0-9]|8(?:[0-8][0-9]|9[0-9]?));?)+$'), mapcss._tag_capture(capture_tags, 2, tags, 'gauge'))))
                 except mapcss.RuleAbort: pass
             if match:
                 # group:tr("suspicious tag combination")
@@ -2778,7 +2778,7 @@ class Josm_numeric(PluginMapCSS):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((not set_imprecise_gauge) and (not set_unusual_gauge) and (mapcss.regexp_test(self.re_70dc3282, mapcss._match_regex(tags, self.re_7e626945))) and (mapcss._tag_capture(capture_tags, 0, tags, 'gauge')) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 1, self.re_33ecb9da, '^((14(?:3[0-4]|[4-9])|(?:14[0-2]|(?:1[0-3]|9)[0-9])[0-9]?|143|(?:[2-7][0-9]|1[5-9])[0-9]|8(?:[0-8][0-9]|9[0-9]?));?)+$'), mapcss._tag_capture(capture_tags, 1, tags, 'gauge'))) and (mapcss._tag_capture(capture_tags, 2, tags, 'type') == mapcss._value_capture(capture_tags, 2, 'route')))
+                try: match = ((not set_imprecise_gauge) and (not set_unusual_gauge) and (mapcss.regexp_test(self.re_70dc3282, mapcss._match_regex(tags, self.re_7e626945))) and (mapcss._tag_capture(capture_tags, 1, tags, 'gauge')) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 2, self.re_33ecb9da, '^((14(?:3[0-4]|[4-9])|(?:14[0-2]|(?:1[0-3]|9)[0-9])[0-9]?|143|(?:[2-7][0-9]|1[5-9])[0-9]|8(?:[0-8][0-9]|9[0-9]?));?)+$'), mapcss._tag_capture(capture_tags, 2, tags, 'gauge'))) and (mapcss._tag_capture(capture_tags, 5, tags, 'type') == mapcss._value_capture(capture_tags, 5, 'route')))
                 except mapcss.RuleAbort: pass
             if match:
                 # group:tr("suspicious tag combination")

--- a/plugins/Josm_transport.py
+++ b/plugins/Josm_transport.py
@@ -290,7 +290,7 @@ class Josm_transport(PluginMapCSS):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((set_pt_route) and (not mapcss._tag_capture(capture_tags, 0, tags, 'public_transport:version')))
+                try: match = ((set_pt_route) and (not mapcss._tag_capture(capture_tags, 1, tags, 'public_transport:version')))
                 except mapcss.RuleAbort: pass
             if match:
                 # -osmoseItemClassLevel:"2140/21401/3"
@@ -305,11 +305,11 @@ class Josm_transport(PluginMapCSS):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((set_pt_route) and (not mapcss._tag_capture(capture_tags, 0, tags, 'network')))
+                try: match = ((set_pt_route) and (not mapcss._tag_capture(capture_tags, 1, tags, 'network')))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((set_pt_route_master) and (not mapcss._tag_capture(capture_tags, 0, tags, 'network')))
+                try: match = ((set_pt_route_master) and (not mapcss._tag_capture(capture_tags, 1, tags, 'network')))
                 except mapcss.RuleAbort: pass
             if match:
                 # -osmoseItemClassLevel:"2140/21402/3"
@@ -324,11 +324,11 @@ class Josm_transport(PluginMapCSS):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((set_pt_route) and (not mapcss._tag_capture(capture_tags, 0, tags, 'operator')))
+                try: match = ((set_pt_route) and (not mapcss._tag_capture(capture_tags, 1, tags, 'operator')))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((set_pt_route_master) and (not mapcss._tag_capture(capture_tags, 0, tags, 'operator')))
+                try: match = ((set_pt_route_master) and (not mapcss._tag_capture(capture_tags, 1, tags, 'operator')))
                 except mapcss.RuleAbort: pass
             if match:
                 # -osmoseItemClassLevel:"2140/21403/3"
@@ -343,11 +343,11 @@ class Josm_transport(PluginMapCSS):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((set_pt_route) and (not mapcss._tag_capture(capture_tags, 0, tags, 'from')))
+                try: match = ((set_pt_route) and (not mapcss._tag_capture(capture_tags, 1, tags, 'from')))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((set_pt_route) and (not mapcss._tag_capture(capture_tags, 0, tags, 'to')))
+                try: match = ((set_pt_route) and (not mapcss._tag_capture(capture_tags, 1, tags, 'to')))
                 except mapcss.RuleAbort: pass
             if match:
                 # -osmoseItemClassLevel:"2140/21405/3"
@@ -379,11 +379,11 @@ class Josm_transport(PluginMapCSS):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((set_pt_route) and (not mapcss._tag_capture(capture_tags, 0, tags, 'colour')) and (mapcss._tag_capture(capture_tags, 1, tags, 'color')))
+                try: match = ((set_pt_route) and (not mapcss._tag_capture(capture_tags, 1, tags, 'colour')) and (mapcss._tag_capture(capture_tags, 2, tags, 'color')))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((set_pt_route_master) and (not mapcss._tag_capture(capture_tags, 0, tags, 'colour')) and (mapcss._tag_capture(capture_tags, 1, tags, 'color')))
+                try: match = ((set_pt_route_master) and (not mapcss._tag_capture(capture_tags, 1, tags, 'colour')) and (mapcss._tag_capture(capture_tags, 2, tags, 'color')))
                 except mapcss.RuleAbort: pass
             if match:
                 # throwError:tr("The color of the public transport line should be in a colour tag")
@@ -401,11 +401,11 @@ class Josm_transport(PluginMapCSS):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((set_pt_route) and (mapcss.regexp_test(mapcss._value_capture(capture_tags, 0, self.re_25554804), mapcss._tag_capture(capture_tags, 0, tags, 'operator'))) and (mapcss.inside(self.father.config.options, 'FR')))
+                try: match = ((set_pt_route) and (mapcss.regexp_test(mapcss._value_capture(capture_tags, 1, self.re_25554804), mapcss._tag_capture(capture_tags, 1, tags, 'operator'))) and (mapcss.inside(self.father.config.options, 'FR')))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((set_pt_route_master) and (mapcss.regexp_test(mapcss._value_capture(capture_tags, 0, self.re_25554804), mapcss._tag_capture(capture_tags, 0, tags, 'operator'))) and (mapcss.inside(self.father.config.options, 'FR')))
+                try: match = ((set_pt_route_master) and (mapcss.regexp_test(mapcss._value_capture(capture_tags, 1, self.re_25554804), mapcss._tag_capture(capture_tags, 1, tags, 'operator'))) and (mapcss.inside(self.father.config.options, 'FR')))
                 except mapcss.RuleAbort: pass
             if match:
                 # throwError:tr("Check the operator tag : this operator does not exist, it may be a typo")
@@ -417,11 +417,11 @@ class Josm_transport(PluginMapCSS):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((set_pt_route) and (mapcss.regexp_test(mapcss._value_capture(capture_tags, 0, self.re_25554804), mapcss._tag_capture(capture_tags, 0, tags, 'network'))) and (mapcss.inside(self.father.config.options, 'FR')))
+                try: match = ((set_pt_route) and (mapcss.regexp_test(mapcss._value_capture(capture_tags, 1, self.re_25554804), mapcss._tag_capture(capture_tags, 1, tags, 'network'))) and (mapcss.inside(self.father.config.options, 'FR')))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((set_pt_route_master) and (mapcss.regexp_test(mapcss._value_capture(capture_tags, 0, self.re_25554804), mapcss._tag_capture(capture_tags, 0, tags, 'network'))) and (mapcss.inside(self.father.config.options, 'FR')))
+                try: match = ((set_pt_route_master) and (mapcss.regexp_test(mapcss._value_capture(capture_tags, 1, self.re_25554804), mapcss._tag_capture(capture_tags, 1, tags, 'network'))) and (mapcss.inside(self.father.config.options, 'FR')))
                 except mapcss.RuleAbort: pass
             if match:
                 # throwError:tr("Check the network tag : this network does not exist, it may be a typo")
@@ -452,11 +452,11 @@ class Josm_transport(PluginMapCSS):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((set_pt_route) and (mapcss._tag_capture(capture_tags, 0, tags, 'interval')) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 1, self.re_2fe0817d, '^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$'), mapcss._tag_capture(capture_tags, 1, tags, 'interval'))))
+                try: match = ((set_pt_route) and (mapcss._tag_capture(capture_tags, 1, tags, 'interval')) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 2, self.re_2fe0817d, '^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$'), mapcss._tag_capture(capture_tags, 2, tags, 'interval'))))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((set_pt_route_master) and (mapcss._tag_capture(capture_tags, 0, tags, 'interval')) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 1, self.re_2fe0817d, '^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$'), mapcss._tag_capture(capture_tags, 1, tags, 'interval'))))
+                try: match = ((set_pt_route_master) and (mapcss._tag_capture(capture_tags, 1, tags, 'interval')) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 2, self.re_2fe0817d, '^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$'), mapcss._tag_capture(capture_tags, 2, tags, 'interval'))))
                 except mapcss.RuleAbort: pass
             if match:
                 # throwError:tr("The interval is invalid (try a number of minutes)")
@@ -478,11 +478,11 @@ class Josm_transport(PluginMapCSS):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((set_pt_route) and (mapcss._tag_capture(capture_tags, 0, tags, 'duration')) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 1, self.re_2fe0817d, '^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$'), mapcss._tag_capture(capture_tags, 1, tags, 'duration'))))
+                try: match = ((set_pt_route) and (mapcss._tag_capture(capture_tags, 1, tags, 'duration')) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 2, self.re_2fe0817d, '^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$'), mapcss._tag_capture(capture_tags, 2, tags, 'duration'))))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((set_pt_route_master) and (mapcss._tag_capture(capture_tags, 0, tags, 'duration')) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 1, self.re_2fe0817d, '^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$'), mapcss._tag_capture(capture_tags, 1, tags, 'duration'))))
+                try: match = ((set_pt_route_master) and (mapcss._tag_capture(capture_tags, 1, tags, 'duration')) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 2, self.re_2fe0817d, '^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$'), mapcss._tag_capture(capture_tags, 2, tags, 'duration'))))
                 except mapcss.RuleAbort: pass
             if match:
                 # throwError:tr("The duration is invalid (try a number of minutes)")
@@ -501,11 +501,11 @@ class Josm_transport(PluginMapCSS):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((set_pt_route) and (mapcss._tag_capture(capture_tags, 0, tags, 'interval:conditional')) and (not mapcss._tag_capture(capture_tags, 1, tags, 'interval')))
+                try: match = ((set_pt_route) and (mapcss._tag_capture(capture_tags, 1, tags, 'interval:conditional')) and (not mapcss._tag_capture(capture_tags, 2, tags, 'interval')))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((set_pt_route_master) and (mapcss._tag_capture(capture_tags, 0, tags, 'interval:conditional')) and (not mapcss._tag_capture(capture_tags, 1, tags, 'interval')))
+                try: match = ((set_pt_route_master) and (mapcss._tag_capture(capture_tags, 1, tags, 'interval:conditional')) and (not mapcss._tag_capture(capture_tags, 2, tags, 'interval')))
                 except mapcss.RuleAbort: pass
             if match:
                 # throwError:tr("Missing interval tag to specify the main interval")
@@ -517,11 +517,11 @@ class Josm_transport(PluginMapCSS):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((set_pt_route) and (mapcss._tag_capture(capture_tags, 0, tags, 'interval:conditional')) and (not mapcss._tag_capture(capture_tags, 1, tags, 'opening_hours')))
+                try: match = ((set_pt_route) and (mapcss._tag_capture(capture_tags, 1, tags, 'interval:conditional')) and (not mapcss._tag_capture(capture_tags, 2, tags, 'opening_hours')))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((set_pt_route_master) and (mapcss._tag_capture(capture_tags, 0, tags, 'interval:conditional')) and (not mapcss._tag_capture(capture_tags, 1, tags, 'opening_hours')))
+                try: match = ((set_pt_route_master) and (mapcss._tag_capture(capture_tags, 1, tags, 'interval:conditional')) and (not mapcss._tag_capture(capture_tags, 2, tags, 'opening_hours')))
                 except mapcss.RuleAbort: pass
             if match:
                 # throwError:tr("Missing opening_hours tag")

--- a/plugins/Josm_unnecessary.py
+++ b/plugins/Josm_unnecessary.py
@@ -471,43 +471,43 @@ class Josm_unnecessary(PluginMapCSS):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'boundary')) and (mapcss._tag_capture(capture_tags, 1, tags, 'area') in ('yes', 'true', '1')) and (nds[0] == nds[-1]))
+                try: match = ((mapcss._tag_capture(capture_tags, 1, tags, 'boundary')) and (mapcss._tag_capture(capture_tags, 2, tags, 'area') in ('yes', 'true', '1')) and (nds[0] == nds[-1]))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'indoor')) and (mapcss._tag_capture(capture_tags, 1, tags, 'area') in ('yes', 'true', '1')) and (not mapcss._tag_capture(capture_tags, 2, tags, 'highway')) and (mapcss._tag_capture(capture_tags, 3, tags, 'indoor') != mapcss._value_const_capture(capture_tags, 3, 'no', 'no')) and (nds[0] == nds[-1]))
+                try: match = ((mapcss._tag_capture(capture_tags, 1, tags, 'indoor')) and (mapcss._tag_capture(capture_tags, 2, tags, 'area') in ('yes', 'true', '1')) and (not mapcss._tag_capture(capture_tags, 3, tags, 'highway')) and (mapcss._tag_capture(capture_tags, 4, tags, 'indoor') != mapcss._value_const_capture(capture_tags, 4, 'no', 'no')) and (nds[0] == nds[-1]))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'office')) and (mapcss._tag_capture(capture_tags, 1, tags, 'area') in ('yes', 'true', '1')) and (nds[0] == nds[-1]))
+                try: match = ((mapcss._tag_capture(capture_tags, 1, tags, 'office')) and (mapcss._tag_capture(capture_tags, 2, tags, 'area') in ('yes', 'true', '1')) and (nds[0] == nds[-1]))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'place')) and (mapcss._tag_capture(capture_tags, 1, tags, 'area') in ('yes', 'true', '1')) and (not mapcss._tag_capture(capture_tags, 2, tags, 'highway')) and (nds[0] == nds[-1]))
+                try: match = ((mapcss._tag_capture(capture_tags, 1, tags, 'place')) and (mapcss._tag_capture(capture_tags, 2, tags, 'area') in ('yes', 'true', '1')) and (not mapcss._tag_capture(capture_tags, 3, tags, 'highway')) and (nds[0] == nds[-1]))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'amenity')) and (mapcss._tag_capture(capture_tags, 1, tags, 'area') in ('yes', 'true', '1')) and (not mapcss._tag_capture(capture_tags, 2, tags, 'highway')) and (nds[0] == nds[-1]))
+                try: match = ((mapcss._tag_capture(capture_tags, 1, tags, 'amenity')) and (mapcss._tag_capture(capture_tags, 2, tags, 'area') in ('yes', 'true', '1')) and (not mapcss._tag_capture(capture_tags, 3, tags, 'highway')) and (nds[0] == nds[-1]))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'building')) and (mapcss._tag_capture(capture_tags, 1, tags, 'area') in ('yes', 'true', '1')) and (nds[0] == nds[-1]))
+                try: match = ((mapcss._tag_capture(capture_tags, 1, tags, 'building')) and (mapcss._tag_capture(capture_tags, 2, tags, 'area') in ('yes', 'true', '1')) and (nds[0] == nds[-1]))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'landuse')) and (mapcss._tag_capture(capture_tags, 1, tags, 'area') in ('yes', 'true', '1')) and (not mapcss._tag_capture(capture_tags, 2, tags, 'highway')) and (nds[0] == nds[-1]))
+                try: match = ((mapcss._tag_capture(capture_tags, 1, tags, 'landuse')) and (mapcss._tag_capture(capture_tags, 2, tags, 'area') in ('yes', 'true', '1')) and (not mapcss._tag_capture(capture_tags, 3, tags, 'highway')) and (nds[0] == nds[-1]))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'leisure')) and (mapcss._tag_capture(capture_tags, 1, tags, 'area') in ('yes', 'true', '1')) and (not mapcss._tag_capture(capture_tags, 2, tags, 'highway')) and (mapcss._tag_capture(capture_tags, 3, tags, 'leisure') != mapcss._value_const_capture(capture_tags, 3, 'track', 'track')) and (mapcss._tag_capture(capture_tags, 4, tags, 'leisure') != mapcss._value_const_capture(capture_tags, 4, 'slipway', 'slipway')) and (nds[0] == nds[-1]))
+                try: match = ((mapcss._tag_capture(capture_tags, 1, tags, 'leisure')) and (mapcss._tag_capture(capture_tags, 2, tags, 'area') in ('yes', 'true', '1')) and (not mapcss._tag_capture(capture_tags, 3, tags, 'highway')) and (mapcss._tag_capture(capture_tags, 4, tags, 'leisure') != mapcss._value_const_capture(capture_tags, 4, 'track', 'track')) and (mapcss._tag_capture(capture_tags, 5, tags, 'leisure') != mapcss._value_const_capture(capture_tags, 5, 'slipway', 'slipway')) and (nds[0] == nds[-1]))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'natural')) and (mapcss._tag_capture(capture_tags, 1, tags, 'area') in ('yes', 'true', '1')) and (nds[0] == nds[-1]))
+                try: match = ((mapcss._tag_capture(capture_tags, 1, tags, 'natural')) and (mapcss._tag_capture(capture_tags, 2, tags, 'area') in ('yes', 'true', '1')) and (nds[0] == nds[-1]))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'shop')) and (mapcss._tag_capture(capture_tags, 1, tags, 'area') in ('yes', 'true', '1')) and (nds[0] == nds[-1]))
+                try: match = ((mapcss._tag_capture(capture_tags, 1, tags, 'shop')) and (mapcss._tag_capture(capture_tags, 2, tags, 'area') in ('yes', 'true', '1')) and (nds[0] == nds[-1]))
                 except mapcss.RuleAbort: pass
             if match:
                 # group:tr("unnecessary tag")
@@ -527,23 +527,23 @@ class Josm_unnecessary(PluginMapCSS):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway') == mapcss._value_capture(capture_tags, 0, 'rest_area')) and (mapcss._tag_capture(capture_tags, 1, tags, 'area') in ('yes', 'true', '1')) and (nds[0] == nds[-1]))
+                try: match = ((mapcss._tag_capture(capture_tags, 1, tags, 'highway') == mapcss._value_capture(capture_tags, 1, 'rest_area')) and (mapcss._tag_capture(capture_tags, 2, tags, 'area') in ('yes', 'true', '1')) and (nds[0] == nds[-1]))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway') == mapcss._value_capture(capture_tags, 0, 'services')) and (mapcss._tag_capture(capture_tags, 1, tags, 'area') in ('yes', 'true', '1')) and (nds[0] == nds[-1]))
+                try: match = ((mapcss._tag_capture(capture_tags, 1, tags, 'highway') == mapcss._value_capture(capture_tags, 1, 'services')) and (mapcss._tag_capture(capture_tags, 2, tags, 'area') in ('yes', 'true', '1')) and (nds[0] == nds[-1]))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'aeroway') == mapcss._value_capture(capture_tags, 0, 'aerodrome')) and (mapcss._tag_capture(capture_tags, 1, tags, 'area') in ('yes', 'true', '1')) and (nds[0] == nds[-1]))
+                try: match = ((mapcss._tag_capture(capture_tags, 1, tags, 'aeroway') == mapcss._value_capture(capture_tags, 1, 'aerodrome')) and (mapcss._tag_capture(capture_tags, 2, tags, 'area') in ('yes', 'true', '1')) and (nds[0] == nds[-1]))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'waterway') == mapcss._value_capture(capture_tags, 0, 'riverbank')) and (mapcss._tag_capture(capture_tags, 1, tags, 'area') in ('yes', 'true', '1')) and (nds[0] == nds[-1]))
+                try: match = ((mapcss._tag_capture(capture_tags, 1, tags, 'waterway') == mapcss._value_capture(capture_tags, 1, 'riverbank')) and (mapcss._tag_capture(capture_tags, 2, tags, 'area') in ('yes', 'true', '1')) and (nds[0] == nds[-1]))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'aeroway') == mapcss._value_capture(capture_tags, 0, 'helipad')) and (mapcss._tag_capture(capture_tags, 1, tags, 'area') in ('yes', 'true', '1')) and (nds[0] == nds[-1]))
+                try: match = ((mapcss._tag_capture(capture_tags, 1, tags, 'aeroway') == mapcss._value_capture(capture_tags, 1, 'helipad')) and (mapcss._tag_capture(capture_tags, 2, tags, 'area') in ('yes', 'true', '1')) and (nds[0] == nds[-1]))
                 except mapcss.RuleAbort: pass
             if match:
                 # group:tr("unnecessary tag")


### PR DESCRIPTION
Per the wiki on tag capture: (https://josm.openstreetmap.de/wiki/Help/Validator/MapCSSTagChecker) "Classes and pseudoclasses do also count."

Rather than counting in mapcss2osmose (which is fairly difficult as some tags get 'cleaned' away (ex `:completely_downloaded`) and the sequence of the tags gets shuffled around for optimization, count it where it's freshly parsed and store the index it as a property of the captured selector.

First attempt at fixing https://github.com/osm-fr/osmose-backend/issues/1535
I accidentally did this on the other mapcss PR...

Todo: testing, test cases